### PR TITLE
conf/layer: rename trustx-{rpi|layer} to gyroidos-{rpi|layer} + compressed kernel image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
 	}
 
 	stages {
-		stage('build GyroidOS') {
+		stage('prepare vars') {
 			steps {
 				script {
 					REPO_NAME = determineRepoName()
@@ -23,20 +23,34 @@ pipeline {
 						BASE_BRANCH = env.BRANCH_NAME
 					}
 				}
+			}
+		}
 
-				build job: "../gyroidos/${BASE_BRANCH}", wait: true, parameters: [
-					string(name: "PR_BRANCHES", value: "${REPO_NAME}=${env.BRANCH_NAME},${env.PR_BRANCHES}"),
-					string(name: "GYROID_ARCH", value: "arm64"),
-					string(name: "GYROID_MACHINE", value: "raspberrypi3-64"),
-					string(name: "BUILD_INSTALLER", value: "n")
-				]
+		stage ('build GyroidOS') {
+			parallel {
+				stage ('Raspberry Pi 3 64 bit') {
+					steps {
 
-				build job: "../gyroidos/${BASE_BRANCH}", wait: true, parameters: [
-					string(name: "PR_BRANCHES", value: "${REPO_NAME}=${env.BRANCH_NAME},${env.PR_BRANCHES}"),
-					string(name: "GYROID_ARCH", value: "arm32"),
-					string(name: "GYROID_MACHINE", value: "raspberrypi2"),
-					string(name: "BUILD_INSTALLER", value: "n")
-				]
+						build job: "../gyroidos/${BASE_BRANCH}", wait: true, parameters: [
+							string(name: "PR_BRANCHES", value: "${REPO_NAME}=${env.BRANCH_NAME},${env.PR_BRANCHES}"),
+							string(name: "GYROID_ARCH", value: "arm64"),
+							string(name: "GYROID_MACHINE", value: "raspberrypi3-64"),
+							string(name: "BUILD_INSTALLER", value: "n")
+						]
+					}
+				}
+
+				stage ('Raspberry Pi 2 32 bit') {
+					steps {
+
+						build job: "../gyroidos/${BASE_BRANCH}", wait: true, parameters: [
+							string(name: "PR_BRANCHES", value: "${REPO_NAME}=${env.BRANCH_NAME},${env.PR_BRANCHES}"),
+							string(name: "GYROID_ARCH", value: "arm32"),
+							string(name: "GYROID_MACHINE", value: "raspberrypi2"),
+							string(name: "BUILD_INSTALLER", value: "n")
+						]
+					}
+				}
 			}
 		}
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
 	agent any
 
 	parameters {
-		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of additional pull request branches (e.g. meta-trustx=PR-177,meta-trustx-rpi=PR-2,gyroidos_build=PR-97)')
+		string(name: 'PR_BRANCHES', defaultValue: '', description: 'Comma separated list of additional pull request branches (e.g. meta-gyroidos=PR-177,meta-gyroidos-rpi=PR-2,gyroidos_build=PR-97)')
 	}
 
 	stages {

--- a/conf/gyroidos/raspberrypi2.inc
+++ b/conf/gyroidos/raspberrypi2.inc
@@ -5,5 +5,7 @@ MACHINEOVERRIDES =. "raspberrypi2:"
 
 GYROIDOS_CONTAINER_ARCH = "qemuarm"
 
+DISTRO_FEATURES:remove = " tmedbg-extended"
+
 # Kernel image name
 SDIMG_KERNELIMAGE = "kernel7.img"

--- a/conf/gyroidos/raspberrypi3-64.inc
+++ b/conf/gyroidos/raspberrypi3-64.inc
@@ -6,7 +6,7 @@ MACHINEOVERRIDES =. "raspberrypi3-64:"
 GYROIDOS_CONTAINER_ARCH = "qemuarm64"
 
 # Kernel image name
-KERNEL_IMAGETYPE_DIRECT = "Image"
+KERNEL_IMAGETYPE_DIRECT = "Image.gz"
 SDIMG_KERNELIMAGE = "kernel8.img"
 
 # if SERIAL_CONSOLES is set and ENABLE_UART is false, getty will flood

--- a/conf/gyroidos/raspberrypi4-64.inc
+++ b/conf/gyroidos/raspberrypi4-64.inc
@@ -5,6 +5,9 @@ MACHINEOVERRIDES =. "raspberrypi4-64:"
 
 GYROIDOS_CONTAINER_ARCH = "qemuarm64"
 
+# enable compressed kernel image
+KERNEL_IMAGETYPE_DIRECT = "Image.gz"
+
 # if SERIAL_CONSOLES is set and ENABLE_UART is false, getty will flood
 # the LOGTTY with error messages. Clear SERIAL_CONSOLES to silence errors.
 python () {

--- a/conf/gyroidos/raspberrypi5.inc
+++ b/conf/gyroidos/raspberrypi5.inc
@@ -5,6 +5,9 @@ MACHINEOVERRIDES =. "raspberrypi5:"
 
 GYROIDOS_CONTAINER_ARCH = "qemuarm64"
 
+# enable compressed kernel image
+KERNEL_IMAGETYPE_DIRECT = "Image.gz"
+
 # currently not included by meta-raspberrypi
 RPI_KERNEL_DEVICETREE:append = " broadcom/bcm2712-rpi-500.dtb"
 

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -5,10 +5,10 @@ BBFILES := "${BBFILES} ${LAYERDIR}/recipes-*/*/*.bb \
 	   ${LAYERDIR}/images/*.bb*"
 
 
-BBFILE_COLLECTIONS += "trustx-rpi"
-BBFILE_PATTERN_trustx-rpi := "^${LAYERDIR}/"
-BBFILE_PRIORITY_trustx-rpi := "8"
+BBFILE_COLLECTIONS += "gyroidos-rpi"
+BBFILE_PATTERN_gyroidos-rpi := "^${LAYERDIR}/"
+BBFILE_PRIORITY_gyroidos-rpi := "8"
 
-LAYERDEPENDS_trustx-rpi = "trustx-layer raspberrypi"
+LAYERDEPENDS_gyroidos-rpi = "gyroidos-layer raspberrypi"
 
-LAYERSERIES_COMPAT_trustx-rpi += "kirkstone"
+LAYERSERIES_COMPAT_gyroidos-rpi += "kirkstone"

--- a/images/gyroidos-cml-initramfs.bbappend
+++ b/images/gyroidos-cml-initramfs.bbappend
@@ -2,3 +2,8 @@
 # remove the openssh server from the CML to reduce initramfs size in dev builds
 PACKAGE_INSTALL:remove = "${@oe.utils.vartrue('RPI_SECURE_BOOT', 'openssh-sshd', '', d)}"
 PACKAGE_INSTALL:remove = "${@oe.utils.vartrue('RPI_SECURE_BOOT', 'ssh-keys', '', d)}"
+
+# remove gdb which is about 100 MB to reduce size of debug images and accelerate boot
+PACKAGE_INSTALL:remove = "cmld-dbg"
+PACKAGE_INSTALL:remove = "gdb"
+PACKAGE_INSTALL:remove = "gdbserver"

--- a/recipes-bsp/bootfiles/rpi-bootfiles.bbappend
+++ b/recipes-bsp/bootfiles/rpi-bootfiles.bbappend
@@ -1,0 +1,10 @@
+# updated versions also used in scarthgap
+RPIFW_DATE = "20240319"
+SRCREV = "9f24f4bc2bdd07ffd158cfbb4bce88a2efc4c1f5"
+SHORTREV = "${@d.getVar("SRCREV", False).__str__()[:7]}"
+
+RPIFW_SRC_URI = "https://api.github.com/repos/raspberrypi/firmware/tarball/9f24f4bc2bdd07ffd158cfbb4bce88a2efc4c1f5;downloadfilename=raspberrypi-firmware-${SHORTREV}.tar.gz"
+RPIFW_S = "${WORKDIR}/raspberrypi-firmware-${SHORTREV}"
+
+SRC_URI = "${RPIFW_SRC_URI}"
+SRC_URI[sha256sum] = "4b436f8946b139c6a1202375ef55d4848e3bcd8c1a9cb47000e06d7ecec828f7"


### PR DESCRIPTION
In layer.conf, we also change the name from the former codename-based trustx-layer and trustx-rpi to gyroidos-layer and gyroidos-rpi.