### PR TITLE
recipes-kernel/linux/linux-raspberrypi: Create buildhistory

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi%.bbappend
+++ b/recipes-kernel/linux/linux-raspberrypi%.bbappend
@@ -1,5 +1,9 @@
 require recipes-kernel/linux/linux-gyroidos.inc
 
+# enable buildhistory for this recipe to allow SRCREV extraction
+inherit buildhistory
+BUILDHISTORY_COMMIT = "0"
+
 SRC_URI += "\
 	file://gyroidos-rpi.cfg \
 "


### PR DESCRIPTION
Enable buildhistory for this recipe to allow extracting the used SRCREV after the build.