### PR TITLE
treewide: Rename container multiconfig to guestos

### DIFF
--- a/conf/gyroidos/raspberrypi-generic.inc
+++ b/conf/gyroidos/raspberrypi-generic.inc
@@ -11,7 +11,7 @@ GYROIDOS_HARDWARE = "arm"
 GYROIDOS_LOGTTY = "tty11"
 
 PACKAGE_CLASSES = "package_ipk"
-BBMULTICONFIG = "container"
+BBMULTICONFIG = "guestos"
 
 PREFERRED_PROVIDER_virtual/kernel:${MACHINE} ?= "linux-raspberrypi-dev"
 PREFERRED_PROVIDER_virtual/kernel:gyroidos-cml ?= "linux-raspberrypi-dev"

--- a/conf/gyroidos/raspberrypi2.inc
+++ b/conf/gyroidos/raspberrypi2.inc
@@ -3,7 +3,7 @@ require raspberrypi-generic.inc
 MACHINE="raspberrypi2"
 MACHINEOVERRIDES =. "raspberrypi2:"
 
-GYROIDOS_CONTAINER_ARCH = "qemuarm"
+GYROIDOS_GUESTOS_ARCH = "qemuarm"
 
 DISTRO_FEATURES:remove = " tmedbg-extended"
 

--- a/conf/gyroidos/raspberrypi3-64.inc
+++ b/conf/gyroidos/raspberrypi3-64.inc
@@ -3,7 +3,7 @@ require raspberrypi-generic.inc
 MACHINE="raspberrypi3-64"
 MACHINEOVERRIDES =. "raspberrypi3-64:"
 
-GYROIDOS_CONTAINER_ARCH = "qemuarm64"
+GYROIDOS_GUESTOS_ARCH = "qemuarm64"
 
 # Kernel image name
 KERNEL_IMAGETYPE_DIRECT = "Image.gz"

--- a/conf/gyroidos/raspberrypi4-64.inc
+++ b/conf/gyroidos/raspberrypi4-64.inc
@@ -3,7 +3,7 @@ require raspberrypi-generic.inc
 MACHINE="raspberrypi4-64"
 MACHINEOVERRIDES =. "raspberrypi4-64:"
 
-GYROIDOS_CONTAINER_ARCH = "qemuarm64"
+GYROIDOS_GUESTOS_ARCH = "qemuarm64"
 
 # enable compressed kernel image
 KERNEL_IMAGETYPE_DIRECT = "Image.gz"

--- a/conf/gyroidos/raspberrypi5.inc
+++ b/conf/gyroidos/raspberrypi5.inc
@@ -3,7 +3,7 @@ require raspberrypi-generic.inc
 MACHINE="raspberrypi5"
 MACHINEOVERRIDES =. "raspberrypi5:"
 
-GYROIDOS_CONTAINER_ARCH = "qemuarm64"
+GYROIDOS_GUESTOS_ARCH = "qemuarm64"
 
 # enable compressed kernel image
 KERNEL_IMAGETYPE_DIRECT = "Image.gz"


### PR DESCRIPTION
Adapt according to gyroidos wide changes due to naming collisions with meta-virtualization.