### PR TITLE
recipes-kernel: linux-raspberrypi: switch protocol to https

### DIFF
--- a/recipes-kernel/linux/linux-raspberrypi%.bbappend
+++ b/recipes-kernel/linux/linux-raspberrypi%.bbappend
@@ -9,6 +9,9 @@ SRC_URI += "\
 "
 SRC_URI:append:raspberrypi5 = " file://gyroidos-rpi5.cfg"
 
+SRC_URI:remove = "git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA}"
+SRC_URI:append = " git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=${LINUX_RPI_KMETA_BRANCH};destsuffix=${KMETA};protocol=https "
+
 LINUX_VERSION_EXTENSION = "-gyroidos"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux-raspberrypi:"


### PR DESCRIPTION
For upstream yocto mirrors the git protocol was disabled lately. Overwrite SRC_URI for yocto-kernel-cache with appended 'protocol=https' to fix following error:

   ERROR: ExpansionError during parsing [...]/meta-raspberrypi/recipes-kernel/linux/linux-raspberrypi-dev.bb
   bb.data_smart.ExpansionError: [...] \
   	ls-remote git://git.yoctoproject.org/yocto-kernel-cache  failed with exit code 128, output:
   fatal: unable to connect to git.yoctoproject.org:
   git.yoctoproject.org[0: 104.18.0.115]: errno=Connection timed out
   git.yoctoproject.org[1: 104.18.1.115]: errno=Connection timed out
   git.yoctoproject.org[2: 2606:4700::6812:73]: errno=Network is unreachable
   git.yoctoproject.org[3: 2606:4700::6812:173]: errno=Network is unreachable

   The variable dependency chain for the failure is: fetcher_hashes_dummyfunc[vardepvalue]

   ERROR: Parsing halted due to errors, see error messages above

This was also submitted upstream to meta-raspberrypi: https://github.com/agherzan/meta-raspberrypi/pull/1601

If the upstream PR gets merge, dwe have to revert this commit here.